### PR TITLE
Update ARM to Node 6.9 and latest source code

### DIFF
--- a/Dockerfile.arm
+++ b/Dockerfile.arm
@@ -1,6 +1,4 @@
-#Latest version of node tested on.
-#FROM node:4.1.2-slim
-FROM alexellis2/node4.x-arm:v6
+FROM alexellis2/nodejs-armhf:6.9.2
 
 WORKDIR /app
 

--- a/README.md
+++ b/README.md
@@ -42,11 +42,22 @@ $ docker service create \
 
 [@alexellisuk](https://twitter.com/alexellisuk) has pushed an image to the Docker Hub as `alexellis2/visualizer-arm:latest` it will run the code on an ARMv6 or ARMv7 device such as the Raspberry Pi.
 
+```
+$ docker service create \
+  --name=viz \
+  --publish=8080:8080/tcp \
+  --constraint=node.role==manager \
+  --mount=type=bind,src=/var/run/docker.sock,dst=/var/run/docker.sock \
+  alexellis2/visualizer-arm:0.4
+```
+
 If you would like to build the image from source run the following command:
 
 ```
 $ docker build -f Dockerfile.arm -t visualizer-arm:latest .
 ```
+
+[View on Docker Hub](https://hub.docker.com/r/alexellis2/visualizer-arm/tags/)
 
 ## Running on Windows
 


### PR DESCRIPTION
Hi @ManoMarks 

I've done the following:

* Updated instructions
* Updated pushed ARM image to latest source code
* Added instructions for `docker swarm service create` on the RPi

Latest image on Hub - [tag 0.4](https://hub.docker.com/r/alexellis2/visualizer-arm/tags/)

Thanks,

Alex