### PR TITLE
Fix repositioning bug on node title blocks

### DIFF
--- a/src/vis-physical/styles.less
+++ b/src/vis-physical/styles.less
@@ -123,7 +123,6 @@
     background-color:white;
     overflow:visible;
     z-index:500;
-    position:absolute;
   }
 
   .node-content{


### PR DESCRIPTION
position:absolute causes the node container to dodge the title block and throw off alignment