### PR TITLE
Use Windows named pipe

### DIFF
--- a/server.js
+++ b/server.js
@@ -78,10 +78,11 @@ if (process.env.DOCKER_HOST) {
 
     if (docker_host) {
         options.host = docker_host;
-		    options.port = docker_port;
-	  }
-	  else {
-		    options.socketPath = '/var/run/docker.sock';
+        options.port = docker_port;
+    } else if (process.platform === 'win32') {
+        options.socketPath = '\\\\.\\pipe\\docker_engine';
+    } else {
+        options.socketPath = '/var/run/docker.sock';
     }
 
     var req = request(options, (res) => {


### PR DESCRIPTION
I've tested Visualizer with Windows Server Insider 16278 and Docker 17.09.0-ce-rc2 which allows me to map the Windows named pipe `\\.\pipe\docker_engine` into a Windows container.
This is the equivalent to the Unix socket `/var/run/docker.sock`.

This PR adds the usage of the Windows named pipe if running on Windows.

My `Dockerfile.insider` to build the example image `stefanscherer/visualizer-windows:insider` that is also available on Docker Hub:

```Dockerfile
FROM stefanscherer/node-windows:8.4.0-insider

WORKDIR /app

# Only run npm install if these files change.
ADD ./package.json /app/package.json

# Install dependencies
RUN npm install --unsafe-perm=true

# Add the rest of the sources
ADD . /app

USER ContainerAdministrator
# Build the app
RUN npm run dist

# Number of milliseconds between polling requests. Default is 200.
ENV MS 200

EXPOSE 8080

CMD ["npm.cmd","start"]
```


After building the image and running it

```
docker run -v //./pipe/docker_engine://./pipe/docker_engine -d -p 8080:8080 stefanscherer/visualizer-windows:insider
```

The Visualizer is running and can monitor the services in the swarm. Only from time to time there are some connection problems to that named pipe. Here is a screenshot with some debug console.logs that shows that the most of the requests are successful.

<img width="1440" alt="visualizer-whoami-named-pipe" src="https://user-images.githubusercontent.com/207759/30785299-4a7c9310-a165-11e7-9d34-56c3dec1ab53.png">

This problem may be related to https://github.com/Microsoft/go-winio/issues/67 which we found running Portainer with a Windows named pipe in a Windows container. So this is no problem of the Visualizer itself.

/cc @friism
