### PR TITLE
Better CSS for labels/overflow on hover

### DIFF
--- a/src/data-provider.js
+++ b/src/data-provider.js
@@ -172,16 +172,18 @@ let physicalStructProvider = ([initialNodes, initialContainers]) => {
                             name = node.Description.Hostname;
                             if (name.length > 0) {
                                 currentnode.Description.Hostname = name;
-                                currentnode.name = name + " <br/> " + node.Spec.Role +
-                                    " <br/>" + (currentnode.Description.Resources.MemoryBytes / 1024 / 1024 / 1024).toFixed(3) + "G RAM <br/>" +
-                                    (currentnode.Description.Platform.Architecture) + "/" + (currentnode.Description.Platform.OS) + "<br/>";
+                                currentnode.name = name + " <br/><span class='noderole'>" + node.Spec.Role +
+                                    "</span><br/><span class='nodemem'>" + (currentnode.Description.Resources.MemoryBytes / 1024 / 1024 / 1024).toFixed(3) + "G RAM</span><br/>" +
+                                    "<span class='nodeplatform'>" + (currentnode.Description.Platform.Architecture) + "/" + (currentnode.Description.Platform.OS) + "</span>" +
+                                    "<div class='labelarea'>";
                                 for (var key in node.Spec.Labels) {
                                     if (node.Spec.Labels[key].length > 0) {
-                                        currentnode.name += " <br/> " + key + "=" + node.Spec.Labels[key];
+                                        currentnode.name += " <br/><span class='nodelabel'>" + key + "=" + node.Spec.Labels[key] + "</span>";
                                     } else {
-                                        currentnode.name += " <br/> " + key;
+                                        currentnode.name += " <br/><span class='nodelabel'>" + key + "</span>";
                                     }
                                 }
+                                currentnode.name += "</div>"
                             }
                             updateNode(currentnode, node.state, node.Spec);
                         }

--- a/src/main.less
+++ b/src/main.less
@@ -33,6 +33,25 @@ html,body{
     > svg{fill: @gray-darker;}
   }
 }
+
+.labelarea{
+  font-size: 45%;
+}
+
+.noderole{
+  font-size: 90%;
+  font-weight: bold;
+}
+.nodemem{
+  font-size: 75%;
+}
+.nodeplatform{
+  font-size: 80%;
+}
+.nodelabel{
+  font-style: italic;
+}
+
 #app {
   margin: 0 auto;
 }

--- a/src/vis-physical/styles.less
+++ b/src/vis-physical/styles.less
@@ -123,6 +123,8 @@
     width:auto;
     background-color:white;
     overflow:visible;
+    white-space: normal;
+    word-break: break-word;
     z-index:500;
   }
 


### PR DESCRIPTION
Given UCP adds quite a few labels (and some of them quite long) to Swarm
nodes, I updated the font sizes of the various details about a node and
had overflow force wrapping on hover so that text doesn't go all over
the screen.

Signed-off-by: Phil Estes <estesp@gmail.com>

No need to merge unless others think this is reasonable; I'm going to use it privately at least for demos with UCP. Here's what it looks like with this PR applied to the visualizer:
<img width="675" alt="label-size-pr-screenshot" src="https://user-images.githubusercontent.com/1397980/31517564-556ab23a-af6a-11e7-9239-f22c1105ea30.png">
