### PR TITLE
Zeropad minutes

### DIFF
--- a/src/data-provider.js
+++ b/src/data-provider.js
@@ -75,7 +75,7 @@ let physicalStructProvider = ([initialNodes, initialContainers]) => {
                 let imageNameRegex = /([^/]+?)(\:([^/]+))?$/;
                 let imageNameMatches = imageNameRegex.exec(cloned.Spec.ContainerSpec.Image);
                 let tagName = imageNameMatches[3];
-                let dateStamp = dt.getDate() + "/" + (dt.getMonth() + 1) + " " + dt.getHours() + ":" + dt.getMinutes();
+                let dateStamp = dt.getDate() + "/" + (dt.getMonth() + 1) + " " + dt.getHours() + ":" + _.padStart(dt.getMinutes(), 2, "0");
                 let startState = cloned.Status.State;
 
 


### PR DESCRIPTION
Timestamps with minute count lower than 10 should be zeropadded such that `19:6` becomes `19:06`.
![image](https://user-images.githubusercontent.com/6364586/33034310-b8a07462-ce27-11e7-9493-ae3f831d038e.png)
