### PR TITLE
Revert "Zeropad minutes"

### DIFF
--- a/src/data-provider.js
+++ b/src/data-provider.js
@@ -75,7 +75,7 @@ let physicalStructProvider = ([initialNodes, initialContainers]) => {
                 let imageNameRegex = /([^/]+?)(\:([^/]+))?$/;
                 let imageNameMatches = imageNameRegex.exec(cloned.Spec.ContainerSpec.Image);
                 let tagName = imageNameMatches[3];
-                let dateStamp = dt.getDate() + "/" + (dt.getMonth() + 1) + " " + dt.getHours() + ":" + _.padStart(dt.getMinutes(), 2, "0");
+                let dateStamp = dt.getDate() + "/" + (dt.getMonth() + 1) + " " + dt.getHours() + ":" + dt.getMinutes();
                 let startState = cloned.Status.State;
 
 


### PR DESCRIPTION
Reverts dockersamples/docker-swarm-visualizer#94 because #99 reverted to an earlier version of Lodash. There are features lacking in Lodash 4.17.4 such as findWhere and bindAll that we don't have time to refactor for. If you want to zerpad the minutes please find another way