### PR TITLE
[ARM] Use arm32v6/node alpine base image

### DIFF
--- a/Dockerfile.arm
+++ b/Dockerfile.arm
@@ -1,4 +1,4 @@
-FROM alexellis2/nodejs-armhf:6.9.2
+FROM arm32v6/node:9-alpine
 
 WORKDIR /app
 

--- a/Dockerfile.arm
+++ b/Dockerfile.arm
@@ -1,4 +1,4 @@
-FROM arm32v6/node:9-alpine
+FROM arm32v6/node:8-alpine
 
 WORKDIR /app
 


### PR DESCRIPTION
By changing the base image to [arm32v6/node](https://hub.docker.com/r/arm32v6/node/) I reduced the image size from 416MB to 155MB.

Might not sound like much, but keep in mind that Raspberry Pis and other ARM based microcomputers are often equipped with litte memory.

![image](https://user-images.githubusercontent.com/1589939/33516725-e62612f8-d777-11e7-833d-687c0dc780d9.png)

It's running on my Pi for a week now without issues.

