### PR TITLE
Fixes #68: failed healthchecks due to file path

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,6 +34,6 @@ ENV MS=1000 CTX_ROOT=/
 
 EXPOSE 8080
 
-HEALTHCHECK CMD node healthcheck.js || exit 1
+HEALTHCHECK CMD node /app/healthcheck.js || exit 1
 
 CMD ["npm","start"]


### PR DESCRIPTION
Seemed node didn't like relative paths. Tried several things like `exec` mode for the CMD, and also tried`./healthcheck.js`, but it only seems to work as a healthcheck if full path is used.

Weird that `docker exec <containerid> node healthcheck.js` worked manually, so docker must be running the healthcheck slightly differently.

`¯\_(ツ)_/¯`