### PR TITLE
Change tag 0.4 to latest for arm

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,14 +55,18 @@ $ docker service create \
   --publish=8080:8080/tcp \
   --constraint=node.role==manager \
   --mount=type=bind,src=/var/run/docker.sock,dst=/var/run/docker.sock \
-  alexellis2/visualizer-arm:0.4
+  alexellis2/visualizer-arm:latest
 ```
+
+* Update/rebuild the image:
 
 If you would like to build the image from source run the following command:
 
 ```
 $ docker build -f Dockerfile.arm -t visualizer-arm:latest .
 ```
+
+> Make sure you do this on a Raspberry Pi directly.
 
 [View on Docker Hub](https://hub.docker.com/r/alexellis2/visualizer-arm/tags/)
 


### PR DESCRIPTION
Signed-off-by: Alex Ellis <alexellis2@gmail.com>

Hi Mano,

I wanted to raise this PR to update the references for the ARM image. It's easier if they both point to `latest` so I've written a small patch.

I also wanted to re-iterate that users can build this image themselves whenever they want a more up to date version. #101 

Keep up the great work - this is a very useful tool 👍 

Alex