### PR TITLE
Revert "updating package.json to remove another vulnerability"

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "express": "^4.13.3",
     "less": "^2.5.3",
     "less-loader": "^2.0.0",
-    "lodash": "^4.17.5",
+    "lodash": "^3.10.1",
     "normalize.css": "^3.0.3",
     "request": "^2.65.0",
     "superagent": "3.7.0",


### PR DESCRIPTION
Think this is responsible for breaking since `_.findWhere` isn't in 4.x lodash please can you revert?
Happy to help fixing and removing the dependency in slowertime
Looks like it repopens #98 though maybe different reasons
https://github.com/dockersamples/docker-swarm-visualizer/search?q=findwhere&unscoped_q=findwhere