### PR TITLE
feat: add filter on nodes according to labels

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -39,6 +39,15 @@ tabPhysical.addEventListener('click', () => {
     filterDiv.classList.add('hide');
     filterDiv.classList.remove('show');
   }
+  filterDiv = document.querySelector('#filter-nodes-wrapper');
+  if (filterDiv.classList.value.indexOf('hide') >= 0) {
+    filterDiv.classList.remove('hide');
+    filterDiv.classList.add('show');
+  }
+  else {
+    filterDiv.classList.add('hide');
+    filterDiv.classList.remove('show');
+  }
 });
 
 /* Enable polling */

--- a/src/utils/filter-containers.js
+++ b/src/utils/filter-containers.js
@@ -2,7 +2,8 @@ let filterTimeout;
 
 function filterTimeoutCallback() {
   let newHistory = encodeURI(document.querySelector('#filter').value);
-  history.pushState({}, '', '?filter=' + newHistory);
+  let newHistoryNodes = encodeURI(document.querySelector('#filter-nodes').value);
+  history.pushState({}, '', '?filter=' + newHistory + '&filterNodes=' + newHistoryNodes);
 }
 
 function filterHistory() {

--- a/src/utils/filter-nodes.js
+++ b/src/utils/filter-nodes.js
@@ -1,0 +1,79 @@
+let filterNodesTimeout;
+
+function filterNodesTimeoutCallback() {
+  let newHistory = encodeURI(document.querySelector('#filter-nodes').value);
+  history.pushState({}, '', '?filterNodes=' + newHistory);
+}
+
+function filterNodesHistory() {
+  if (typeof filterNodesTimeout !== 'undefined') {
+    clearTimeout(filterNodesTimeout);
+  }
+  filterNodesTimeout = setTimeout(filterNodesTimeoutCallback, 500);
+}
+
+function filterNodesMap(element) {
+  let component = element.split('=');
+  this[component[0]] = component[1];
+  return this;
+}
+
+export function filterNodes() {
+
+  // Fetch DOM elements, break each word in input filter.
+  let filterNodesValues = document.querySelector('#filter-nodes').value.trim().split(' ');
+  let nodes = document.querySelectorAll('.node');
+
+  // Iterate through each node.
+  for (let i = 0; i < nodes.length; i++) {
+
+    // Get node title.
+    let spanText = nodes[i].querySelector('.labelarea').querySelector('span').innerHTML;
+
+    // Define hidden by default.
+    let hide = true;
+
+    // Iterate through each word, show if any are found.
+    for (let j = 0; j < filterNodesValues.length; j++) {
+      if (spanText.indexOf(filterNodesValues[j]) >= 0) {
+        hide = false;
+        break;
+      }
+    }
+
+    // Display or hide node, based on filter.
+    if (hide) {
+      nodes[i].classList.add('hide');
+      nodes[i].classList.remove('show');
+    }
+    else {
+      nodes[i].classList.remove('hide');
+      nodes[i].classList.add('show');
+    }
+  }
+  filterNodesHistory();
+}
+
+export function filterNodesOnLoad() {
+  let filterNodesInput = document.querySelector('#filter-nodes');
+  if (!filterNodesInput) {
+    setTimeout(filterNodesOnLoad, 1000);
+    return;
+  }
+  let search = decodeURIComponent(location.search);
+  if (!search) {
+    return;
+  }
+
+  let searchObj = search
+    .substring(1)
+    .split('&')
+    .map(filterNodesMap, {})[0];
+
+  if (searchObj.filterNodes) {
+    filterNodesInput.value = searchObj.filterNodes;
+    console.log('about to call filterNodes');
+    console.log(typeof filterNodes);
+    setTimeout(filterNodes, 2000);
+  }
+}

--- a/src/utils/filter-nodes.js
+++ b/src/utils/filter-nodes.js
@@ -1,8 +1,9 @@
 let filterNodesTimeout;
 
 function filterNodesTimeoutCallback() {
-  let newHistory = encodeURI(document.querySelector('#filter-nodes').value);
-  history.pushState({}, '', '?filterNodes=' + newHistory);
+  let newHistory = encodeURI(document.querySelector('#filter').value);
+  let newHistoryNodes = encodeURI(document.querySelector('#filter-nodes').value);
+  history.pushState({}, '', '?filter=' + newHistory + '&filterNodes=' + newHistoryNodes);
 }
 
 function filterNodesHistory() {
@@ -28,15 +29,20 @@ export function filterNodes() {
   for (let i = 0; i < nodes.length; i++) {
 
     // Get node title.
-    let spanText = nodes[i].querySelector('.labelarea').querySelector('span').innerHTML;
+    let spanText = nodes[i].querySelector('.labelarea').querySelectorAll('span');
 
     // Define hidden by default.
     let hide = true;
 
     // Iterate through each word, show if any are found.
     for (let j = 0; j < filterNodesValues.length; j++) {
-      if (spanText.indexOf(filterNodesValues[j]) >= 0) {
-        hide = false;
+      for(let k = 0; k < spanText.length; k++) {
+        if (spanText[k].innerHTML.indexOf(filterNodesValues[j]) >= 0) {
+          hide = false;
+          break;
+        }
+      }
+      if(!hide) {
         break;
       }
     }

--- a/src/vis-physical/index.js
+++ b/src/vis-physical/index.js
@@ -6,6 +6,7 @@ import _ from 'lodash';
 
 import { uuidRegExp, capitalize } from '../utils/helpers';
 import { filterContainers, filterOnLoad } from "../utils/filter-containers";
+import { filterNodes, filterNodesOnLoad } from "../utils/filter-nodes";
 
 var { innerWidth:W, innerHeight:H } = window;
 
@@ -25,6 +26,17 @@ let filterInput = filterDiv.append('input')
 
 filterInput.on('keyup', filterContainers);
 filterOnLoad();
+
+let filterNodesDiv = wrapper.append('div')
+    .attr('id', 'filter-nodes-wrapper');
+
+let filterNodesInput = filterNodesDiv.append('input')
+    .attr('id', 'filter-nodes')
+    .attr('placeholder', 'filter nodes on labels');
+
+filterNodesInput.on('keyup', filterNodes);
+filterNodesOnLoad();
+
 
 function removeVis() {
   cluster = wrapper.selectAll('.node-cluster')

--- a/src/vis-physical/styles.less
+++ b/src/vis-physical/styles.less
@@ -238,11 +238,11 @@
   animation: show .5s forwards;
 }
 
-#filter-wrapper.hide,  {
+#filter-wrapper.hide, #filter-nodes-wrapper.hide {
   animation: hide .5s forwards;
 }
 
-#filter-wrapper.show {
+#filter-wrapper.show, #filter-nodes-wrapper.show {
   animation: show .5s forwards;
 }
 
@@ -251,13 +251,5 @@
 }
 
 #vis-physical .node.show {
-  display: block;
-}
-
-#filter-nodes-wrapper.hide {
-  display: none;
-}
-
-#filter-nodes-wrapper.show {
   display: block;
 }

--- a/src/vis-physical/styles.less
+++ b/src/vis-physical/styles.less
@@ -230,18 +230,34 @@
   100% { opacity: 1; transform: scale(1); max-height: 500px; }
 }
 
-#vis-physical .container.hide, #vis-physical .node.hide {
+#vis-physical .container.hide{
   animation: hide .5s forwards;
 }
 
-#vis-physical .container.show, #vis-physical .node.show {
+#vis-physical .container.show {
   animation: show .5s forwards;
 }
 
-#filter-wrapper.hide, #filter-nodes-wrapper.hide {
+#filter-wrapper.hide,  {
   animation: hide .5s forwards;
 }
 
-#filter-wrapper.show, #filter-nodes-wrapper.show {
+#filter-wrapper.show {
   animation: show .5s forwards;
+}
+
+#vis-physical .node.hide {
+  display: none;
+}
+
+#vis-physical .node.show {
+  display: block;
+}
+
+#filter-nodes-wrapper.hide {
+  display: none;
+}
+
+#filter-nodes-wrapper.show {
+  display: block;
 }

--- a/src/vis-physical/styles.less
+++ b/src/vis-physical/styles.less
@@ -230,18 +230,18 @@
   100% { opacity: 1; transform: scale(1); max-height: 500px; }
 }
 
-#vis-physical .container.hide {
+#vis-physical .container.hide, #vis-physical .node.hide {
   animation: hide .5s forwards;
 }
 
-#vis-physical .container.show {
+#vis-physical .container.show, #vis-physical .node.show {
   animation: show .5s forwards;
 }
 
-#filter-wrapper.hide {
+#filter-wrapper.hide, #filter-nodes-wrapper.hide {
   animation: hide .5s forwards;
 }
 
-#filter-wrapper.show {
+#filter-wrapper.show, #filter-nodes-wrapper.show {
   animation: show .5s forwards;
 }


### PR DESCRIPTION
Add a way to filter nodes according to labels

Same behavior than the filter on container except that it scans node's labels instead of containers' names.