### PR TITLE
Wrap contents of nodes with multiple containers to fill wide screens

### DIFF
--- a/src/vis-physical/styles.less
+++ b/src/vis-physical/styles.less
@@ -96,7 +96,6 @@
 
   .node{
     float: left;
-    width: 200px;
     margin-bottom: 20px;
     margin-right: 10px;
     &:last-child{
@@ -131,7 +130,7 @@
   .node-content{
     padding: 0 10px;
     display: flex;
-    flex-direction: column-reverse;
+    flex-wrap: wrap;
     background: @gray-darkerr;
     border: 2px solid lighten(@gray-darker,8%);
     min-height: 500px;
@@ -143,6 +142,7 @@
 
   .container {
     //height: 152px;
+    width: 200px;
     margin-bottom: 5px;
     margin-top: 5px;
     border-radius: 3px;
@@ -184,10 +184,11 @@
     background: @gray-darker;
     border: 2px solid lighten(@gray-darker,8%);
     padding: 15px;
+    display: flex;
     .clear();
   }
   .node-cluster-content:empty {
-     display: none;
+    display: none;
   }
 
   .node-cluster-meta{


### PR DESCRIPTION
Currently, if a cluster has a few nodes with a big number of containers, visualizer doesn't use the wide space correctly.
Was tested only on Chrome, so sorry if I'm missing something.